### PR TITLE
fix testcases T0

### DIFF
--- a/Tareas/T0/functions.py
+++ b/Tareas/T0/functions.py
@@ -27,7 +27,7 @@ def solucionar_tablero(tablero: list) -> list:
 
 if __name__ == "__main__":
     tablero_2x2 = [
-        ['-', 2],
+        ['-', '2'],
         ['-', '-']
     ]
     resultado = verificar_valor_bombas(tablero_2x2)
@@ -40,11 +40,11 @@ if __name__ == "__main__":
     print(tablero_resuelto)
 
     tablero_2x2_sol = [
-        ['T', 2],
+        ['T', '2'],
         ['-', '-']
     ]
 
-    resultado = verificar_alcance_bomba(tablero_2x2, (0, 1))
+    resultado = verificar_alcance_bomba(tablero_2x2_sol, (0, 1))
     print(resultado)  # Debería ser 2
 
     resultado = verificar_tortugas(tablero_2x2_sol)


### PR DESCRIPTION
# Pequeño fix testcases en `functions.py`

Haciendo la tarea, me percaté dos errores  en los testcases del archivo `functions.py`. Hablo sobre esto en mayor profundidad en #50 

## TLDR:
### Typo 1
El enunciado dice que este es el formato del tablero (bombas son `str`):

![Screenshot from 2023-03-22 22-15-46](https://user-images.githubusercontent.com/78695941/227078703-960c6287-57f9-4b65-89df-51ec03220a47.png)

El testcase actual evalua este formato (bombas son `int`):
```python
tablero_2x2 = [
   ['-', 2],
   ['-', '-']
]
```

### Typo 2
Hay dos testcases identicos definidos que divergen en resultados esperados
```python
# functions.py

# ....
tablero_2x2 = [
   ['-', 2],
   ['-', '-']
]
# ....

# lineas 36 y 37 de functions.py
resultado = verificar_alcance_bomba(tablero_2x2, (0, 1))
print(resultado)  # Debería ser 3

# lineas 47 y 48 de functions.py
resultado = verificar_alcance_bomba(tablero_2x2, (0, 1))
print(resultado)  # Debería ser 2
```

## Solución propuesta
- Typo1: Cambiar el datatype de bombas a `string` como lo dice el enunciado
- Typo2: Cambiar la variable evaluada en el testcase de la linea 47 a `tablero_2x2_sol`